### PR TITLE
hide token

### DIFF
--- a/view.py
+++ b/view.py
@@ -13,10 +13,11 @@ from values import values, types
 
 import pyowm
 
-token = '660308305:AAG-0FberRD73c55u6obRVr__fj7LTsjWJM'
+import os
+
+token = os.environ.get('TELEGRAM_TOKEN', '')
 bot = telebot.TeleBot(token, threaded=False)
 
-token = '660308305:AAG-0FberRD73c55u6obRVr__fj7LTsjWJM'
 URL = 'https://api.telegram.org/bot' + token + '/'
 secret = ''
 url = 'https://3b3b95dc.ngrok.io' + secret


### PR DESCRIPTION
Hello 👋 
Here's a PR to remove your Telegram bot token from your code so I can't see it 😉 
I've used `os.environ.get` to get the token from your environment, I'm not sure how you've deployed this so I can't say if this is the best solution for you